### PR TITLE
Fix: Update AmfContext3gpp response code and DB client

### DIFF
--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -253,7 +253,7 @@ func HandleCreateAmfContext3gpp(request *httpwrapper.Request) *httpwrapper.Respo
 		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
 
-	return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
+	return httpwrapper.NewResponse(http.StatusCreated, nil, map[string]interface{}{})
 }
 
 func CreateAmfContext3gppProcedure(collName string, ueId string,
@@ -261,7 +261,7 @@ func CreateAmfContext3gppProcedure(collName string, ueId string,
 ) (*models.ProblemDetails, error) {
 	colleName := SUBSCDATA_AUTHDATA_AUTHSTATUS
 	filters := bson.M{"ueId": ueId}
-	data, errGetOne := AuthDBClient.RestfulAPIGetOne(colleName, filters)
+	data, errGetOne := CommonDBClient.RestfulAPIGetOne(colleName, filters)
 
 	if errGetOne != nil {
 		logger.DataRepoLog.Warnln(errGetOne)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR fixes the AMF Context Creation logic in the UDR.
DB Client Switch: Changed AuthDBClient.RestfulAPIGetOne to CommonDBClient.RestfulAPIGetOne in CreateAmfContext3gppProcedure. The Authentication Status collection was not accessible via the AuthDBClient in this environment, causing valid UEs to be rejected.
Status Code Update: Updated HandleCreateAmfContext3gpp to return http.StatusCreated (201) instead of http.StatusNoContent (204). This ensures the created resource is confirmed and aligns with the UDM's expectation for generating the Location header.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#21](https://github.com/5GC-DEV/udr-cdac/issues/21)

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL
