### PR TITLE
Fix: UDM returns 500 Internal Server Error instead of expected 201 for SMF Registration Request

### DIFF
--- a/datarepository/api_smf_registration_document.go
+++ b/datarepository/api_smf_registration_document.go
@@ -56,8 +56,8 @@ func HTTPCreateSmfContextNon3gpp(c *gin.Context) {
 	}
 
 	req := httpwrapper.NewRequest(c.Request, smfRegistration)
-	req.Params["ueId"] = c.Params.ByName("ueId")
-
+	req.Params["ueId"] = c.Param("ueId")
+	req.Params["smfRegistrationId"] = c.Param("pduSessionId")
 	rsp := producer.HandleCreateSmfContextNon3gpp(req)
 
 	responseBody, err := openapi.Serialize(rsp.Body, "application/json")

--- a/datarepository/routers.go
+++ b/datarepository/routers.go
@@ -548,7 +548,7 @@ var routes = Routes{
 	{
 		"HTTPCreateSmfContextNon3gpp",
 		strings.ToUpper("Put"),
-		"/subscription-data/:ueId/:servingPlmnId/smf-registrations/:pduSessionId",
+		"/subscription-data/:ueId/context-data/smf-registrations/:pduSessionId",
 		HTTPCreateSmfContextNon3gpp,
 	},
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
During execution of the SMF Registration Request for 3GPP Access test case, the UDM is expected to respond with 201 Created, as specified in 3GPP TS 29.503.
However, the current core implementation returns 500 Internal Server Error, which causes the test to fail.
This PR fixes the issue and ensures that the UDM responds with the correct 201 Created status code as per the specification.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #24

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
