### PR TITLE
Fix: UDR not returning 404 for SMF Registration Request (3GPP Access) when not required subscription data is missing

### DIFF
--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -41,6 +41,7 @@ const (
 	SUBSCDATA_CTXDATA_SMSF_3GPPACCESS          = "subscriptionData.contextData.smsf3gppAccess"
 	SUBSCDATA_CTXDATA_SMSF_NON3GPPACCESS       = "subscriptionData.contextData.smsfNon3gppAccess"
 	SUBSCDATA_AUTHDATA_AUTHSTATUS              = "subscriptionData.authenticationData.authenticationStatus"
+	SUBSCDATA_PROVISION_SMDATA                 = "subscriptionData.provisionedData.smData"
 )
 
 var CurrentResourceUri string
@@ -3132,6 +3133,11 @@ func HandleCreateSmfContextNon3gpp(request *httpwrapper.Request) *httpwrapper.Re
 		logger.DataRepoLog.Warnln(err)
 	}
 
+	if !IsUeSupported(ueId) {
+		pd := util.ProblemDetailsNotFound("UE not found")
+		return httpwrapper.NewResponse(http.StatusNotFound, nil, pd)
+	}
+
 	response, status := CreateSmfContextNon3gppProcedure(SmfRegistration, collName, ueId, pduSessionId)
 
 	switch status {
@@ -3166,6 +3172,19 @@ func CreateSmfContextNon3gppProcedure(SmfRegistration models.SmfRegistration,
 	} else {
 		return putData, http.StatusOK
 	}
+}
+
+func IsUeSupported(ueId string) bool {
+	collName := SUBSCDATA_PROVISION_SMDATA
+	filter := bson.M{"ueId": ueId}
+
+	ueData, err := CommonDBClient.RestfulAPIGetOne(collName, filter)
+	if err != nil {
+		logger.DataRepoLog.Warnln(err)
+		return false
+	}
+
+	return ueData != nil
 }
 
 func HandleDeleteSmfContext(request *httpwrapper.Request) *httpwrapper.Response {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
When the SMF sends an SMF Registration Request for 3GPP Access to the UDR, the UDR does not return a 404 Not Found response when the required subscription data is missing. Instead, the request is handled without the expected error response.

According to 3GPP specifications, if the requested subscription data does not exist, the UDR should respond with a 404 Not Found error.
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #26

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
